### PR TITLE
Fix retry() auto-failing after timeout or manual abort

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -341,7 +341,7 @@
 
     function timedOut() {
       self._timedOut = true
-      self.request.abort()      
+      self.request.abort()
     }
 
     function error(resp, msg, t) {
@@ -366,6 +366,8 @@
     }
 
   , retry: function () {
+      this._aborted=false;
+      this._timedOut=false;
       init.call(this, this.o, this.fn)
     }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1821,6 +1821,59 @@
     })
   })
 
+  sink('Retry after timeout/abort', function (test, ok) {
+    test('timeout', function (complete) {
+      var calledError = false,
+          req = ajax({
+            url: '/tests/quicker-second-response'
+            , type: 'json'
+            , timeout: 250
+            , error: function (err, msg) {
+              ok(err, 'received error response')
+              try {
+                ok(err && err.status === 0, 'correctly caught timeout')
+                ok(msg && msg === 'Request is aborted: timeout', 'timeout message received')
+              } catch (e) {
+                ok(true, 'IE is a troll')
+              }
+              calledError = true;
+              setTimeout(function() { req.retry.call(req); }, 100);
+            }
+            , success: function(resp) {
+              ok(resp.headers && resp.method && resp.query, 'Received correct response body');
+              ok(calledError, 'Error was called first because of timeout, then succeed on retry.');
+              complete();
+            }
+          })
+    });
+
+    test('abort', function (complete) {
+      var calledError = false,
+        req = ajax({
+          url: '/tests/quicker-second-response'
+          , type: 'json'
+          , timeout: 3000
+          , error: function (err, msg) {
+            ok(err, 'received error response')
+            try {
+              ok(err && err.status === 0, 'correctly caught abort')
+            } catch (e) {
+              ok(true, 'IE is a troll')
+            }
+            calledError = true;
+            setTimeout(function() { req.retry.call(req); }, 100);
+          }
+          , success: function(resp) {
+            ok(resp.headers && resp.method && resp.query, 'Received correct response body');
+            ok(calledError, 'Error was called first because of abort, then succeeds on retry.');
+            complete();
+          }
+        });
+
+      setTimeout(function() { req.abort.call(req); }, 300);
+    });
+  })
+
   start()
 
 }(reqwest))


### PR DESCRIPTION
Reqwest internally tracks the _aborted and _timedout status of it's request, however when you retry the request these variables are not reset resulting in an immediate failure upon retry. This change has been submitted as a pull request to the main libs repo ded/reqwest