### PR TITLE
Phantom sometimes remove the content-type header

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -750,14 +750,6 @@
         , success: function (resp) {
             ok(methodMatch(resp, 'GET'), 'correct request method (GET)')
             ok(
-                headerMatch(
-                    resp
-                  , 'content-type'
-                  , 'application/x-www-form-urlencoded'
-                )
-              , 'correct Content-Type request header'
-            )
-            ok(
                 headerMatch(resp, 'x-requested-with', 'XMLHttpRequest')
               , 'correct X-Requested-With header'
             )
@@ -781,10 +773,6 @@
         , success: function (resp) {
             ok(methodMatch(resp, 'GET'), 'correct request method (GET)')
             ok(
-                headerMatch(resp, 'content-type', 'yapplication/foobar')
-              , 'correct Content-Type request header'
-            )
-            ok(
                 headerMatch(resp, 'x-requested-with', 'XMLHttpRequest')
               , 'correct X-Requested-With header'
             )
@@ -807,14 +795,6 @@
         , dataType: 'json' // should map to 'type'
         , success: function (resp) {
             ok(methodMatch(resp, 'GET'), 'correct request method (GET)')
-            ok(
-                headerMatch(
-                    resp
-                  , 'content-type'
-                  , 'application/x-www-form-urlencoded'
-                )
-              , 'correct Content-Type request header'
-            )
             ok(
                 headerMatch(resp, 'x-requested-with', 'XMLHttpRequest')
               , 'correct X-Requested-With header'
@@ -867,14 +847,6 @@
           // happens with headers
         , headers: { one: 1, two: 2 }
         , success: function (resp) {
-            ok(
-                headerMatch(
-                    resp
-                  , 'content-type'
-                  , 'application/x-www-form-urlencoded'
-                )
-              , 'correct Content-Type request header'
-            )
             ok(
                 headerMatch(resp, 'x-requested-with', 'XMLHttpRequest')
               , 'correct X-Requested-With header'


### PR DESCRIPTION
It seems that if the request body is empty there is no requirement for the client to send a Content-Type header in the request. It seems Phantom's XHR object respects this and does not send the Content-Type header in this scenario. Fixing tests to reflect this.

http://stackoverflow.com/questions/26913526/http-content-type-header-and-body-are-not-transmitted-when-sent-from-within-phan

https://github.com/ariya/phantomjs/issues/11885
