### PR TITLE
fixes request.abort() function non-existent for IE8/9

### DIFF
--- a/src/reqwest.js
+++ b/src/reqwest.js
@@ -341,7 +341,9 @@
 
     function timedOut() {
       self._timedOut = true
-      self.request.abort()
+      if(typeof self.request !== 'undefined' && typeof self.request.abort === 'function') {
+        self.request.abort();
+      }
     }
 
     function error(resp, msg, t) {
@@ -362,7 +364,9 @@
   Reqwest.prototype = {
     abort: function () {
       this._aborted = true
-      this.request.abort()
+      if(typeof this.request !== 'undefined' && typeof this.request.abort === 'function') {
+        this.request.abort();
+      }
     }
 
   , retry: function () {


### PR DESCRIPTION
With IE8 and IE9, the server returning a status of '204 No content' will cause IE to internally throw a status of 12343, which reqwest thinks is an error, and will try to abort. During that process, reqwest attempts to call `request.abort()` on the internal XHR object, on which the 'abort' method does not exist. for reference: https://github.com/ded/reqwest/issues/73